### PR TITLE
Fix: Missing domain prop resulted in automatic redirect loop

### DIFF
--- a/backend/src/main/java/com/assemble/backend/configurations/security/LogoutCustomizer.java
+++ b/backend/src/main/java/com/assemble/backend/configurations/security/LogoutCustomizer.java
@@ -12,22 +12,29 @@ package com.assemble.backend.configurations.security;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
 import org.springframework.stereotype.Component;
 
 @Component
 @AllArgsConstructor
 public class LogoutCustomizer implements Customizer<LogoutConfigurer<HttpSecurity>> {
 
+    private Environment environment;
+
     @Override
     public void customize( LogoutConfigurer<HttpSecurity> httpSecurityLogoutConfigurer ) {
+        String domain = environment.getProperty( "server.servlet.session.cookie.domain" );
+
         httpSecurityLogoutConfigurer
                 .logoutUrl( "/api/auth/logout" )
-                .deleteCookies( "SESSION", "XSRF-TOKEN" )
-                .logoutSuccessHandler( ( ( request, response, authentication ) ->
-                        response.setStatus( HttpServletResponse.SC_NO_CONTENT )
-                ) );
+                .logoutSuccessHandler( ( ( request, response, authentication ) -> {
+                    String cookieHeader = "SESSION=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=" + domain;
+                    response.addHeader( "Set-Cookie", cookieHeader );
+                    response.setStatus( HttpServletResponse.SC_NO_CONTENT );
+                } ) );
     }
 }

--- a/frontend/src/proxy.tsx
+++ b/frontend/src/proxy.tsx
@@ -25,14 +25,18 @@ export default async function proxy( request: NextRequest ) {
             await submitLogout();
         } catch {
             const domain = new URL( request.url ).hostname;
-            cookieStore.delete( {
+            cookieStore.set( {
                 name: "SESSION",
+                value: "",
+                expires: 0,
                 maxAge: 0,
                 path: "/",
                 domain
             } )
-            cookieStore.delete( {
+            cookieStore.set( {
                 name: "XSRF-TOKEN",
+                value: "",
+                expires: 0,
                 maxAge: 0,
                 path: "/",
                 domain

--- a/frontend/src/proxy.tsx
+++ b/frontend/src/proxy.tsx
@@ -23,14 +23,24 @@ export default async function proxy( request: NextRequest ) {
     if ( pathName === LOGOUT_PATH ) {
         try {
             await submitLogout();
-            if ( cookieStore.has( "SESSION" ) ) cookieStore.delete( "SESSION" );
-            if ( cookieStore.has( "XSRF-TOKEN" ) ) cookieStore.delete( "XSRF-TOKEN" );
-
         } catch {
-            cookieStore.delete( "XSRF-TOKEN" );
-            cookieStore.delete( "SESSION" );
+            const domain = new URL( request.url ).hostname;
+            cookieStore.delete( {
+                name: "SESSION",
+                maxAge: 0,
+                path: "/",
+                domain
+            } )
+            cookieStore.delete( {
+                name: "XSRF-TOKEN",
+                maxAge: 0,
+                path: "/",
+                domain
+            } )
         }
+
         let nextUrl = LOGIN_REDIRECT_PATH;
+
         if ( params.has( "next" ) && isValidRoutePath( params.get( "next" )! ) ) {
             nextUrl = params.get( "next" )!;
         }

--- a/frontend/src/services/rest/auth/auth.ts
+++ b/frontend/src/services/rest/auth/auth.ts
@@ -32,6 +32,7 @@ const submitLogout = async () => {
             ...csrf
         }
     } );
+
     if ( response.status === 204 ) {
         await setCookiesFromResponse( response.headers.getSetCookie() );
     }
@@ -48,6 +49,7 @@ const getUserDetails = async () => {
             ...csrf
         }
     } )
+
 
     if ( response.status === 401 || response.status === 404 ) redirect( LOGOUT_PATH );
 


### PR DESCRIPTION
Added domain property to set-cookie on logout
Added fallback cookie in proxy.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout to reliably clear session and CSRF cookies across domains by using domain-aware cookie handling and header-based clearing; logout now returns HTTP 204 on success.
  * Frontend now resets cookies on logout failure with domain-scoped cookie clearing to avoid leftover tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->